### PR TITLE
Update Env.ext.schelp

### DIFF
--- a/HelpSource/Classes/Env.ext.schelp
+++ b/HelpSource/Classes/Env.ext.schelp
@@ -63,12 +63,12 @@ method:: segment
 Segment an envelope into several sub-envelops with crossfade in between each envelope
 	argument:: numSegs
 		How many segments to cut
+	argument:: crossfade
+		The time for crossfading inbetween sub envelopes.
 	argument:: strategy
 		The strategy on where to cut the envelop, available strages are:
 		\atpeak:  Cut the envelope based on the peak time of the envelope, random time will be choosen if segmenting more than peak points was required.
 		\geo: Geometric series
 		\exp: Exponential
 		\random:  Cut on random time
-	argument:: crossfade
-		The time for crossfading inbetween sub envelopes.
 	returns:: An array of arrays including the envelope and wait time for Rutine yield. [[Env, time], [Env, time]]


### PR DESCRIPTION
The order of the second and the third argument are changed. According to the class method definition, crossfade should be the second and strategy should be the third.